### PR TITLE
Add support for ordering results

### DIFF
--- a/query.go
+++ b/query.go
@@ -17,6 +17,8 @@ type Query struct {
 	limit     *limit
 	offset    *offset
 	tail      string
+	orderBy   string
+	orderDesc bool
 }
 
 // Select begins the "select" query formation. The extra argument should contain all other query parts that should not pe parametrised, such as "join" statements - it's optional and can be left empty.
@@ -47,6 +49,21 @@ func (q *Query) Offset(value int) *Query {
 	return q
 }
 
+func (q *Query) OrderBy(column string) *Query {
+	if column != "" {
+		q.orderBy = column
+	}
+	return q
+}
+
+func (q *Query) OrderByDescending(column string) *Query {
+	if column != "" {
+		q.orderBy = column
+		q.orderDesc = true
+	}
+	return q
+}
+
 func (q *Query) Append(tail string) *Query {
 	q.tail += tail
 	return q
@@ -63,6 +80,14 @@ func (q *Query) ToExecutable() (string, []interface{}, error) {
 		queryBuilder.WriteString(" where ")
 		queryBuilder.WriteString(q.where.Print())
 		arguments = append(arguments, q.where.GetOrderedArguments()...)
+	}
+
+	if q.orderBy != "" {
+		queryBuilder.WriteString(" order by ")
+		queryBuilder.WriteString(q.orderBy)
+		if q.orderDesc {
+			queryBuilder.WriteString(" desc")
+		}
 	}
 
 	if q.offset != nil {

--- a/query_test.go
+++ b/query_test.go
@@ -146,3 +146,33 @@ func TestQuery_ToExecutable_LimitOffsetZerosIgnored(t *testing.T) {
 	assert.Equal(t, 1, len(parameters))
 	assert.Equal(t, 1, parameters[0])
 }
+
+func TestQuery_ToExecutable_SelectWithSimpleSingleWhereLimitOffsetAppendOrderBy(t *testing.T) {
+	t.Parallel()
+	query := Select("*", "users", "").Where(WhereBegin(NewWhereItem("id", "=", NewParameter(1)))).Limit(2).Offset(3).Append("returning id").OrderBy("test")
+
+	result, parameters, err := query.ToExecutable()
+
+	expectedResult := "select * from users where (id = $1) order by test offset $2 limit $3 returning id"
+	assert.Nil(t, err)
+	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, 3, len(parameters))
+	assert.Equal(t, 1, parameters[0])
+	assert.Equal(t, 3, parameters[1])
+	assert.Equal(t, 2, parameters[2])
+}
+
+func TestQuery_ToExecutable_SelectWithSimpleSingleWhereLimitOffsetAppendOrderByDesc(t *testing.T) {
+	t.Parallel()
+	query := Select("*", "users", "").Where(WhereBegin(NewWhereItem("id", "=", NewParameter(1)))).Limit(2).Offset(3).Append("returning id").OrderByDescending("test")
+
+	result, parameters, err := query.ToExecutable()
+
+	expectedResult := "select * from users where (id = $1) order by test desc offset $2 limit $3 returning id"
+	assert.Nil(t, err)
+	assert.Equal(t, expectedResult, result)
+	assert.Equal(t, 3, len(parameters))
+	assert.Equal(t, 1, parameters[0])
+	assert.Equal(t, 3, parameters[1])
+	assert.Equal(t, 2, parameters[2])
+}


### PR DESCRIPTION
Since in Postgres the `ORDER BY` clause needs to happen after `WHERE` but before `LIMIT` or `OFFSET`, there was no feasible way to order results when limit or offset were used.

This adds a simple text field that stores the column name (can be multiple ones, since it's essentially just echoing the name provided to SQL) by which the results should be ordered.

Note that if `LIMIT` and `OFFSET` are not used, `Append()` can serve the same purpose anyway.